### PR TITLE
chore: Prometheus podMonitor selector removed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,6 @@ unit-test: ## Run unit tests
 
 integration-test: ## Run integration tests
 	@./scripts/run-test.sh integration examples/sample-app
-	@./scripts/run-test.sh integration examples/sample-prometheus-app
 
 validate: ## Run static checks
 	@pre-commit run --color=always --show-diff-on-failure --all-files

--- a/addons/kube-prometheus-stack/values.yaml
+++ b/addons/kube-prometheus-stack/values.yaml
@@ -48,9 +48,6 @@ kube-prometheus-stack-source:
   prometheusSpec:
     externalUrl: "prometheus.local/"
     rotuePrefix: "/"
-    podMonitorSelector:
-      matchLabels:
-        release: kube-prometheus-stack
   # Required to fix the out-of-sync issues on the this apps suite
   kubelet:
     serviceMonitor:


### PR DESCRIPTION
## What does this PR do?

Since the default selector is used, I figured out that the value for `podMonitor` selector is not needed in the Prometheus Stack.

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have upgraded the [changelog](../CHANGELOG.md) according to the nature of the feature that I am adding to this Pull Request.
