### PR TITLE
chore: Refine CI workflows

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -12,8 +12,8 @@ module.exports = {
       groupName: "Istio Helm Chart"
     }
   ],
-  username: "nearform-renovate-app",
-  gitAuthor: '"Nearform" <nearform@nearform.com>',
+  username: "nearform-renovate-app[bot]",
+  gitAuthor: "NearForm Renovate App Bot <115552475+nearform-renovate-app[bot]@users.noreply.github.com>",
   automergeType: "branch",
   platformAutomerge: true,
   repositories: ['nearform/k8s-kurated-addons'],

--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -17,7 +17,7 @@ module.exports = {
   automergeType: "branch",
   platformAutomerge: true,
   repositories: ['nearform/k8s-kurated-addons'],
-  enabledManagers: ['helmv3', 'github-actions'],
+  enabledManagers: ['asdf', 'helmv3', 'github-actions'],
   prConcurrentLimit: 0,
   branchConcurrentLimit: 0,
   branchNameStrict: true,

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,12 +1,13 @@
 name: Run Integration Tests
 
 on:
-  pull_request:
-    branches:
-      - main
+  pull_request_review:
+    types:
+      - submitted
 
 jobs:
   create-cluster:
+    if: github.event.review.state == 'approved'
     strategy:
       matrix:
         KKA_K8S_VERSION:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,12 +1,13 @@
 name: Run Unit Tests
 
 on:
-  pull_request:
-    branches:
-      - main
+  pull_request_review:
+    types:
+      - submitted
 
 jobs:
   create-cluster:
+    if: github.event.review.state == 'approved'
     strategy:
       matrix:
         KKA_K8S_VERSION:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3.2.0
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v34.58.1
+        uses: renovatebot/github-action@v34.100.1
         with:
           configurationFile: .github/renovate-config.js
           token: "x-access-token:${{ steps.get_installation_token.outputs.token }}"


### PR DESCRIPTION
## What does this PR do?

This PR tackles the following items:
- Adds the `asdf` manager into Renovate Bot, which will allow us to get version bumps for `.tool-versions` from now on
- It will run the preview/integration workflows ( Unit testing and Integration testing CI jobs ) only when a PR will be approved, instead of running on each commit
- Fixes the renovate bot configuration as per documentation ( see https://docs.renovatebot.com/modules/platform/github/#running-as-a-github-app )
- Bump the renovate action version to the latest available

## Related issues

N/A

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have upgraded the [changelog](../CHANGELOG.md) according to the nature of the feature that I am adding to this Pull Request.
