### PR TITLE
chore: Refine preview/integration workflows to skip docs PRs

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   create-cluster:
-    if: github.event.review.state == 'approved'
+    if: github.event.review.state == 'approved' && !startsWith(github.event.pull_request.title, 'docs:')
     strategy:
       matrix:
         KKA_K8S_VERSION:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   create-cluster:
-    if: github.event.review.state == 'approved'
+    if: github.event.review.state == 'approved' && !startsWith(github.event.pull_request.title, 'docs:')
     strategy:
       matrix:
         KKA_K8S_VERSION:


### PR DESCRIPTION
## What does this PR do?

This PR will skip the integration and unit test workflows when a PR title starts with `docs:`

## Related issues

N/A

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have upgraded the [changelog](../CHANGELOG.md) according to the nature of the feature that I am adding to this Pull Request.
