### PR TITLE
fix: Downgrade ArgoCD traffic to HTTP

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -65,7 +65,7 @@ if os.getenv('KKA_DEPLOY_MINIMAL', 'false') == 'false':
         links=['http://localhost:{}'.format(ARGOCD_EXTERNAL_PORT)],
         readiness_probe=probe(
             initial_delay_secs = 20,
-            timeout_secs = 1,
+            timeout_secs = 5,
             period_secs = 10,
             success_threshold = 1,
             failure_threshold = 5,

--- a/Tiltfile
+++ b/Tiltfile
@@ -3,7 +3,7 @@ for env in ['KKA_REPO_NAME', 'KKA_REPO_HOST_PATH', 'KKA_REPO_NODE_PATH', 'KKA_RE
     if os.getenv(env, '') == '': fail('Missing or empty {} env var. Did you run this project using the Makefile?'.format(env))
 
 # ===== Internal variables =====
-ARGOCD_EXTERNAL_PORT = os.getenv('KKA_ARGOCD_EXTERNAL_PORT', 8443)
+ARGOCD_EXTERNAL_PORT = os.getenv('KKA_ARGOCD_EXTERNAL_PORT', 8080)
 ISTIO_HTTP_PORT = os.getenv('KKA_ISTIO_HTTP_PORT', 7080)
 ISTIO_HTTPS_PORT = os.getenv('KKA_ISTIO_HTTPS_PORT', 7443)
 
@@ -61,7 +61,7 @@ if os.getenv('KKA_DEPLOY_MINIMAL', 'false') == 'false':
     ## ArgoCD HTTPS port
     local_resource(
         'argocd-portforward',
-        serve_cmd='kubectl port-forward -n argocd svc/argocd-server {}:443'.format(ARGOCD_EXTERNAL_PORT),
+        serve_cmd='kubectl port-forward -n argocd svc/argocd-server {}:80'.format(ARGOCD_EXTERNAL_PORT),
         links=['http://localhost:{}'.format(ARGOCD_EXTERNAL_PORT)],
         readiness_probe=probe(
             initial_delay_secs = 20,

--- a/addons/argocd/values.yaml
+++ b/addons/argocd/values.yaml
@@ -3,6 +3,10 @@ argocd-source:
   applicationSet:
     enabled: false
 
+  configs:
+    params:
+      server.insecure: true
+
   dex:
     enabled: false
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes the weird port-forwarding termination happening randomly while Tilt is forwarding the traffic on Windows and macOS. The workaround is about downgrading the default traffic from HTTPS to HTTP.

The long version of this issue can be found here: https://github.com/kubernetes/kubernetes/issues/74551 but it triggers a lot more under TLS traffic than on plain HTTP, probably because of how encrypted packets look like and how they go back and forth through the TCP/IP stack.

Additionally, this downgrade will allow end-users to put an HTTPS Load Balancer in front of ArgoCD if required without further issues or configuration requirements.

## Related issues

Fixes #18 

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have upgraded the [changelog](../CHANGELOG.md) according to the nature of the feature that I am adding to this Pull Request.
