### PR TITLE
feat: Move app-of-apps manifest to helm-chart

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -9,14 +9,14 @@ jobs:
   upload-assets:
     runs-on: ubuntu-latest
     steps:
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
       - uses: actions/checkout@v3
 
       - name: Upload files to a GitHub release
         run: |
-          source .envrc
-          cat manifests/app-of-apps.yaml | envsubst > app-of-apps.yaml
+          helm template manifests/bootstrap --set revision=${{ github.ref_name }} > app-of-apps.yaml
           ./scripts/upload-assets.sh ${{ github.repository }} app-of-apps.yaml ${{ github.ref }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          KKA_REPO_URI: https://github.com/${{ github.repository }}.git
-          KKA_REPO_BRANCH: ${{ github.ref_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 argocd/charts
 *Chart.lock
 *charts/
-
+manifests/bootstrap/overrides.local.yaml
 .idea
 local.env
 kind.local.yaml

--- a/README.md
+++ b/README.md
@@ -14,12 +14,15 @@ Therefore, ArgoCD is the main requirement to run this project on your cluster.
 
 Assuming you already have `argocd` (if installed with helm, the name of the chart should be argocd) deployed in your cluster to make deployment successful and all addons synced it is required to verify if following configuration is part of your ArgoCD configuration: [argocd/values.yaml](https://github.com/nearform/k8s-kurated-addons/blob/main/addons/argocd/values.yaml#L23).
 You can check it by describing argo-cd config map:
+
 ```
 kubectl describe cm argocd-cm -n argocd
 ```
+
 Don't apply changes directly to the Config Map, but apply them the in your installation scripts/helm chart values.
 
 Next, you can download the provided `app-of-apps.yaml` in our [latest stable release](https://github.com/nearform/k8s-kurated-addons/releases/latest) and then apply that manifest using this command:
+
 ```bash
 kubectl apply -f app-of-apps.yaml
 ```
@@ -60,6 +63,7 @@ To continue with the deployment, you need a set of tools installed first. You ca
 > **HINT:** If you want to know which commands are available you can always run `make help` on this project.
 
 #### CLI
+
 ![Inner workings of make](docs/img/inner-workings/k8s-addons-internals.png)
 Make sure you've followed the [bootstrap steps](#bootstrap), then:
 
@@ -80,29 +84,31 @@ Make sure you've followed the [bootstrap steps](#bootstrap), then:
 
 1. Deploy the local environment:
 
-    ```bash
-    # Deploy the cluster and run tilt visually
-    $ make
-    ```
+   ```bash
+   # Deploy the cluster and run tilt visually
+   $ make
+   ```
 
-    You can access the Kind K8s cluster using any kubernetes client like kubectl or Lens.<br>
-    [Accessing Argocd UI](https://argo-cd.readthedocs.io/en/stable/getting_started/#3-access-the-argo-cd-api-server)
-
+   You can access the Kind K8s cluster using any kubernetes client like kubectl or Lens.<br>
+   [Accessing Argocd UI](https://argo-cd.readthedocs.io/en/stable/getting_started/#3-access-the-argo-cd-api-server)
 
 2. (Optional) Run the two following resources in tilt to portforward argocd and get the default admin password
 
-    ```
-    - argocd-portforward
-    - argocd-password
-    ```
+   ```
+   - argocd-portforward
+   - argocd-password
+   ```
 
-    > **PLEASE NOTE:** The port forwarding sometimes seems to drop, so re-run the tilt resource to get the connection up and running again.
+   > **PLEASE NOTE:** The port forwarding sometimes seems to drop, so re-run the tilt resource to get the connection up and running again.
+
+3. (Optional) Test app-of-apps values changes using the override feature of the bootstrap app, following the instructions in the `./manifests/bootstrap/overrides.local.yaml.tmpl` file.
 
 #### Cleanup
 
 > **IMPORTANT:** Make sure to run this command while tilt is NOT running.
 
 In order to cleanup the solution from your own local environment you can run:
+
 ```bash
 $ make clean
 ```
@@ -119,6 +125,7 @@ To make the infrastructure test setup easier.
 Before running tests make sure you've followed the [bootstrap steps](#bootstrap).
 
 Once ready, you can use this simple set of commands:
+
 ```bash
 # Create the cluster
 $ KKA_DEPLOY_MINIMAL=true make ci
@@ -134,6 +141,7 @@ See the [examples/sample-app](examples/sample-app) as an example.
 Before running tests make sure you've followed the [bootstrap steps](#bootstrap).
 
 Once ready, you can use this simple set of commands:
+
 ```bash
 # Create the cluster and all the required dependencies
 $ make ci

--- a/manifests/bootstrap/.helmignore
+++ b/manifests/bootstrap/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/manifests/bootstrap/Chart.yaml
+++ b/manifests/bootstrap/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: bootstrap
+description: Bootstrap the app of apps
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/manifests/bootstrap/overrides.local.yaml.tmpl
+++ b/manifests/bootstrap/overrides.local.yaml.tmpl
@@ -2,3 +2,10 @@
 # Just create a copy without the .tmpl extension and [re]run make
 # Tilt will see the new file and include it when loading the helm chart
 # Git ignores the file, so there is no risk of pushing it
+
+# This helm chart values will be merged with the values of
+# the app-of-apps chart defined int the root directory.
+# eg. You can disable the dex addon with:
+# apps:
+#   dex:
+#     excluded: true

--- a/manifests/bootstrap/overrides.local.yaml.tmpl
+++ b/manifests/bootstrap/overrides.local.yaml.tmpl
@@ -1,0 +1,4 @@
+# You can use this file to test values changes locally.
+# Just create a copy without the .tmpl extension and [re]run make
+# Tilt will see the new file and include it when loading the helm chart
+# Git ignores the file, so there is no risk of pushing it

--- a/manifests/bootstrap/templates/app-of-apps.yaml
+++ b/manifests/bootstrap/templates/app-of-apps.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: k8s-kurated-addons
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  project: default
+  source:
+    path: app-of-apps
+    repoURL: {{ .Values.repoURL }}
+    targetRevision: {{ .Values.revision }}
+    helm:
+      parameters:
+        - name: repoURL
+          value: {{ .Values.repoURL }}
+        - name: subChartsRevision
+          value: {{ .Values.revision }}
+      {{- if .Values.apps }}
+      values: |-
+        apps:
+{{ .Values.apps | toYaml | indent 10}}
+      {{- end }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/manifests/bootstrap/values.yaml
+++ b/manifests/bootstrap/values.yaml
@@ -1,0 +1,2 @@
+revision: HEAD
+repoURL: "https://github.com/nearform/k8s-kurated-addons.git"


### PR DESCRIPTION
## What does this PR do?

We started this to solve one main issue, using environment variables in the app-of-apps.yaml file had us use `envsubst` in the Tilt file, blocking the nice live reloading functionality of Tilt and forcing us to release a file with many inline values.  

Replacing the `app-of-apps.yaml` file in favor of a helm chart gives us multiple benefits without changing the end-user interface, which remains the same single YAML file.

For the end user, as I said above, the interface will remain the same, the pipeline that generates the asset will run `helm template bootstrap --set revision=<git-tag>` to produce an `app-of-apps.yaml` manifest similar to the one we are releasing at the moment.

From a developer perspective, the helm-chart is a good place to test add-on changes dynamically since Tilt monitors the directory and reloads the ArgoCD application on changes.

We agreed that we wanted to maintain the option of disabling add-ons via environment variables and so [parse_excluded_env_vars](https://github.com/nearform/k8s-kurated-addons/pull/31/files#diff-c2ee8653e1d6b85f0aadf87cd438a9250806c052877248442be4d434cbc52425R5-R27) function was created in the Tilt file.

## Related issues

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have upgraded the [changelog](../CHANGELOG.md) according to the nature of the feature that I am adding to this Pull Request.
