### PR TITLE
chore: Migrate integration test to a larger Linux runner

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -16,27 +16,21 @@ jobs:
             "kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315",
             "kindest/node:v1.25.3@sha256:f1de3b0670462f43280114eccceab8bf1b9576d2afe0582f8f74529da6fd0365",
           ]
-    runs-on: macos-12
+    runs-on:
+      labels: ubuntu-latest-4-cores
     steps:
       - uses: actions/checkout@v3
 
       - name: Integration test
         run: |
-          # Install GNU tools and make use them from now on
-          brew install bash make coreutils
-          PATH="$(brew --prefix)/opt/make/libexec/gnubin:$PATH"
+          # Install envsubst
+          sudo apt-get update && sudo apt-get install -y gettext
           # Install asdf and expose to PATH
-          brew install asdf
-          . $(brew --prefix)/opt/asdf/libexec/asdf.sh
-          # Install Docker
-          brew install docker
+          git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.10.2
+          . $HOME/.asdf/asdf.sh
           # Add asdf plugins and install tools in .tool-versions
           make asdf_install
-          # Print Colima version
-          colima version
-          # Run Colima ( 3 vCPU, 12GB RAM, 12GB Disk )
-          colima start --cpu 3 --memory 12 --disk 12
-          # Create a local branch to allow the next steps to work
+          # Create a local branch to allow the next step to work
           git checkout -b ci
           # Deploy cluster
           make ci


### PR DESCRIPTION
## What does this PR do?

This PR migrates the integration test workflow to make use of the larger Linux runner `4 CPU/16GB RAM`, which should be enough to correctly run our current stack.

## Related issues

N/A

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have upgraded the [changelog](../CHANGELOG.md) according to the nature of the feature that I am adding to this Pull Request.
