### PR TITLE
chore: Set 15m timeout for integration/unit testing pipelines

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -18,6 +18,7 @@ jobs:
           ]
     runs-on:
       labels: ubuntu-latest-4-cores
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -17,6 +17,7 @@ jobs:
             "kindest/node:v1.25.3@sha256:f1de3b0670462f43280114eccceab8bf1b9576d2afe0582f8f74529da6fd0365",
           ]
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
## What does this PR do?

This PR will set a 15 minutes timeout for integration and unit testing pipelines, ensuring they won't run up to 6 hours ( default setting ) if they get stuck. It will also save some costs where special runners are being used.

## Related issues

N/A

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have upgraded the [changelog](../CHANGELOG.md) according to the nature of the feature that I am adding to this Pull Request.
