### PR TITLE
fix: change renovate commit prefix

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
   "branchNameStrict": true,
   "dependencyDashboard": false,
   "enabledManagers": ["asdf", "helmv3", "github-actions"],
-  "extends": ["config:base", ":disableDependencyDashboard", ":semanticCommitTypeAll(deps)"],
+  "extends": ["config:base", ":disableDependencyDashboard", ":semanticCommitTypeAll(ci)"],
   "gitAuthor": "NearForm Renovate App Bot <115552475+nearform-renovate-app[bot]@users.noreply.github.com>",
   "packageRules":
   [


### PR DESCRIPTION
Change renovate commit prefix to match conventional commits policy

## What does this PR do?

Change renovate commit prefix to match conventional commits policy

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have upgraded the [changelog](../CHANGELOG.md) according to the nature of the feature that I am adding to this Pull Request.
