### PR TITLE
feat: remove kubernetes 1.23 from github actions matrix

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -12,7 +12,6 @@ jobs:
       matrix:
         KKA_K8S_VERSION:
           [
-            "kindest/node:v1.23.13@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315",
             "kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315",
             "kindest/node:v1.25.3@sha256:f1de3b0670462f43280114eccceab8bf1b9576d2afe0582f8f74529da6fd0365",
           ]

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -12,7 +12,6 @@ jobs:
       matrix:
         KKA_K8S_VERSION:
           [
-            "kindest/node:v1.23.13@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315",
             "kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315",
             "kindest/node:v1.25.3@sha256:f1de3b0670462f43280114eccceab8bf1b9576d2afe0582f8f74529da6fd0365",
           ]


### PR DESCRIPTION
## What does this PR do?

Removing 1.23 given it's End of Life:2023-02-28

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have upgraded the [changelog](../CHANGELOG.md) according to the nature of the feature that I am adding to this Pull Request.
