### PR TITLE
fix: remove the update changelog entry

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,4 +13,3 @@ Please include a link to the issues related to this Pull Request.
 - [ ] I have checked the [contributing document](../CONTRIBUTING.MD).
 - [ ] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
 - [ ] I have added tests that prove my fix is effective or that my feature works.
-- [ ] I have upgraded the [changelog](../CHANGELOG.md) according to the nature of the feature that I am adding to this Pull Request.


### PR DESCRIPTION
No need to update the changelog since it's something that release please does by itself.

## What does this PR do?

Remove one outdated checkbox from the PR template file

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have upgraded the [changelog](../CHANGELOG.md) according to the nature of the feature that I am adding to this Pull Request.
