### PR TITLE
feat: remove envsubst requirement

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Integration test
         run: |
-          # Install envsubst
-          sudo apt-get update && sudo apt-get install -y gettext
           # Install asdf and expose to PATH
           git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.10.2
           . $HOME/.asdf/asdf.sh

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Unit test
         run: |
-          # Install envsubst
-          sudo apt-get update && sudo apt-get install -y gettext
           # Install asdf and expose to PATH
           git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.10.2
           . $HOME/.asdf/asdf.sh

--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -14,8 +14,6 @@ jobs:
 
       - name: Static check
         run: |
-          # Install envsubst
-          sudo apt-get update && sudo apt-get install -y gettext
           # Install asdf and expose to PATH
           git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.10.2
           . $HOME/.asdf/asdf.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,6 @@ guide, do one of the following:
 
 We use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) in this repo. We encourage contributors to name their PRs and commits accordingly. That is required for keeping the repo clean, and [release-please](https://github.com/googleapis/release-please) to do its job when automating release creation.
 
-
 Basically, the `fix` and `feat` words on commits will trigger new releases (with `fix` being patch versions and `feat` minor versions, unless there is an exclamation mark (`!`) after one of both, which will trigger a major version release). Other keywords won't trigger releases, but they are welcome in order to better readability of the changes made. Examples: `docs`, `chore`, `ci`, `test` and so on.
 
 ## Bug Reports
@@ -61,10 +60,10 @@ Usually you would see your ArgoCD Applications pointing to a Github repository o
 
 How this is done is simple:
 - We use a project named [git-http-backend](https://github.com/ynohat/git-http-backend) where you basically mirror your local folder as an HTTP Git server
-- We mount the **parent folder** of where you clone this repository [in kind](./manifests/kind.yaml#L6-9) so later on the charts can use the `containerPath` as mount volume
+- We mount the **parent folder** of where you clone this repository [in kind](./manifests/kind/templates/cluster.yaml#L6-9) so later on the charts can use the `containerPath` as mount volume
 - We build a docker image of this project locally to ensure it doesn't change in time and no malicious code comes with it, see [utils/git-http-backend/docker](utils/git-http-backend/docker)
 - We create a custom Helm chart to deploy the built container, see [utils/git-http-backend/chart](utils/git-http-backend/chart)
-- We [build and deploy the image as a chart in the cluster via Tilt](./Tiltfile#L12-18) and we pass to the container image the [kind mounted path](./manifests/kind.yaml#L8) of where this repository lives, so you can later access it via the [KKA_REPO_URI defined in the .envrc](./.envrc#L8) ( eg. `http://git-http-backend/git/k8s-kurated-addons` )
+- We [build and deploy the image as a chart in the cluster via Tilt](./Tiltfile#L12-18) and we pass to the container image the [kind mounted path](./manifests/kind/templates/cluster.yaml#L8) of where this repository lives, so you can later access it via the [KKA_REPO_URI defined in the .envrc](./.envrc#L8) ( eg. `http://git-http-backend/git/k8s-kurated-addons` )
 
 **REMEMBER:** As ArgoCD will use the latest commit to checkout changes, you **will have** to commit your changes locally otherwise ArgoCD won't be able to see them. Pushing is **NOT REQUIRED**.
 

--- a/docs/DEX_GITHUB_INTEGRATION.md
+++ b/docs/DEX_GITHUB_INTEGRATION.md
@@ -10,7 +10,7 @@ explained in [GitHub Dex documentation](https://dexidp.io/docs/connectors/github
 
 ## Prerequisites
 * It is assumed that local cluster with Dex addon is already deployed. The needed steps are explained in the [bootstrap section](https://github.com/nearform/k8s-kurated-addons#bootstrap).
-During cluster bootstrap OIDC parameters are already configured. Parameters can be checked in the [kind manifest](https://github.com/nearform/k8s-kurated-addons/blob/main/manifests/kind.yaml).
+During cluster bootstrap OIDC parameters are already configured. Parameters can be checked in the [kind manifest](https://github.com/nearform/k8s-kurated-addons/blob/main/manifests/kind/templates/cluster.yaml).
 * The Kubelogin plugin is installed using [setup instructions](https://github.com/int128/kubelogin#setup).
 * For now, we will use default configuration for Dex addon and make changes as we progress.
 

--- a/manifests/kind/.helmignore
+++ b/manifests/kind/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/manifests/kind/Chart.yaml
+++ b/manifests/kind/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: kind
+description: A Helm chart for Kind
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/manifests/kind/templates/cluster.yaml
+++ b/manifests/kind/templates/cluster.yaml
@@ -1,5 +1,6 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+name: {{ .Values.name }}
 kubeadmConfigPatches:
 - |-
   kind: ClusterConfiguration
@@ -12,11 +13,11 @@ kubeadmConfigPatches:
       oidc-groups-claim: groups
 nodes:
 - role: control-plane
-  image: ${KKA_K8S_VERSION}
+  image: {{ .Values.k8s_version }}
   extraMounts:
-  - hostPath: ${KKA_REPO_HOST_PATH}
-    containerPath: ${KKA_REPO_NODE_PATH}
+  - hostPath:  {{ .Values.repo_host_path }}
+    containerPath: {{ .Values.repo_node_path }}
     readOnly: true
-  - hostPath: ${KKA_REPO_HOST_PATH}/${KKA_REPO_NAME}/.ssl/ca.pem
+  - hostPath: {{ .Values.repo_host_path }}/{{ .Values.repo_name }}/.ssl/ca.pem
     containerPath: /etc/ca-certificates/dex/ca.pem
     readOnly: true

--- a/scripts/kind-up.sh
+++ b/scripts/kind-up.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 
-KIND_PATH="manifests/kind.yaml"
+KIND_PATH="manifests/kind"
 KIND_COMPUTED_PATH="kind.local.yaml"
 
 source .envrc
 
 if ! kind get kubeconfig --name ${KKA_REPO_NAME} > /dev/null 2>&1; then
-cat ${KIND_PATH} | envsubst > ${KIND_COMPUTED_PATH}
-kind create cluster --config ${KIND_COMPUTED_PATH} --name ${KKA_REPO_NAME}
+helm template ${KIND_PATH} --set k8s_version="${KKA_K8S_VERSION}" \
+                           --set repo_host_path="${KKA_REPO_HOST_PATH}" \
+                           --set repo_node_path="${KKA_REPO_NODE_PATH}" \
+                           --set name="${KKA_REPO_NAME}" \
+                           --set repo_name="${KKA_REPO_NAME}" > ${KIND_COMPUTED_PATH}
+
+kind create cluster --config ${KIND_COMPUTED_PATH}
 fi


### PR DESCRIPTION
The repo was using envsubst to template the local kind manifest, unfortunately envsubst is not present in all the environments that are running the code and so after some discussions, we decided to remove envsubst and turn the kind manifest into an helm chart to use the native template functionality.

## What does this PR do?

Please include a summary of the change, and please also include relevant motivation and context. List any dependencies that are required for this change.

## Related issues

Please include a link to the issues related to this Pull Request.

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have upgraded the [changelog](../CHANGELOG.md) according to the nature of the feature that I am adding to this Pull Request.
