### PR TITLE
fix: use POSIX compatible comparison operator

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -48,7 +48,7 @@ export KKA_DEPLOY_MINIMAL="${KKA_DEPLOY_MINIMAL:-false}"
 # Istio
 export KKA_AOA_EXCLUDE_ISTIO="${KKA_AOA_EXCLUDE_ISTIO:-false}"
 # Knative depends on Istio by default, if we exclude it we exclude Knative as well
-if [ "${KKA_AOA_EXCLUDE_ISTIO}" == "true" ]; then
+if [ "${KKA_AOA_EXCLUDE_ISTIO}" = "true" ]; then
 export KKA_AOA_EXCLUDE_KNATIVE="true"
 else
 export KKA_AOA_EXCLUDE_KNATIVE="${KKA_AOA_EXCLUDE_KNATIVE:-false}"


### PR DESCRIPTION
## What does this PR do?

Fixes issue on MacOS terminals (the default is `zsh`) when attempting to source the `.envrc` file.

The error is being generated for the syntax of the `if` statement
``` bash
if [ "${KKA_AOA_EXCLUDE_ISTIO}" == "true" ]; then
  export KKA_AOA_EXCLUDE_KNATIVE="true"
else
```

for compatibility reasons, we should use `=` instead of `==`

## Related issues

Closes #88 

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
- [ ] I have added tests that prove my fix is effective or that my feature works.
