### PR TITLE
fix: replace readarray

### DIFF
--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -20,7 +20,7 @@ if [ "${KKA_DEPLOY_MINIMAL}" == "false" ]; then
   while [ true ]
   do
     ALL_HEALTHY=true
-    readarray -t apps_health < <(argocd app get k8s-kurated-addons -o json | jq -r '.status.resources | .[]? | select(.kind | contains("Application")) | .health.status')
+    IFS=$'\n' read -r -d '' -a apps_health < <(argocd app get k8s-kurated-addons -o json | jq -r '.status.resources | .[]? | select(.kind | contains("Application")) | .health.status')
 
     if (( ${#apps_health[@]} == 0 )); then
       ALL_HEALTHY=false
@@ -34,7 +34,7 @@ if [ "${KKA_DEPLOY_MINIMAL}" == "false" ]; then
     fi
 
     ALL_SYNCED=true
-    readarray -t apps_sync < <(argocd app get k8s-kurated-addons -o json | jq -r '.status.resources | .[]? | select(.kind | contains("Application")) | .status')
+    IFS=$'\n' read -r -d '' -a apps_sync < <(argocd app get k8s-kurated-addons -o json | jq -r '.status.resources | .[]? | select(.kind | contains("Application")) | .status')
     if (( ${#apps_sync[@]} == 0 )); then
       ALL_SYNCED=false
     else
@@ -52,7 +52,7 @@ if [ "${KKA_DEPLOY_MINIMAL}" == "false" ]; then
       argocd app get k8s-kurated-addons
 
       # Print the 10 last lines of logs of apps not currently healthy
-      readarray -t apps < <(argocd app get k8s-kurated-addons -o json | jq -r '.status.resources | .[]? | select(.kind | contains("Application")) | select(.health.status | contains("Progressing")) | .name')
+      IFS=$'\n' read -r -d '' -a apps < <(argocd app get k8s-kurated-addons -o json | jq -r '.status.resources | .[]? | select(.kind | contains("Application")) | select(.health.status | contains("Progressing")) | .name')
       for app in ${apps[@]}
       do
         echo ">> Printing last 10 log lines for $app..."


### PR DESCRIPTION
## What does this PR do?

`readarray` is not supported on Mac as it was introduced in bash v4 and mac uses bash v3

## Related issues

Closes #91 

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
- [ ] I have added tests that prove my fix is effective or that my feature works.
