### PR TITLE
ci: remove automerge configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,10 +11,6 @@
   "packageRules":
   [
     {
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
-    },
-    {
       "matchPaths": ["addons/istio/**"],
       "groupName": "Istio Helm Chart"
     }


### PR DESCRIPTION
## What does this PR do?

With the automerge configuration, every dependency PR that was a minor or a patch is merged immediately after an approval without waiting for the integration tests.

We can set the automerge back once the correct status checks are set in the repo.

## Related issues

Please include a link to the issues related to this Pull Request.

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
- [ ] I have added tests that prove my fix is effective or that my feature works.
