### PR TITLE
feat: Add knative scaling test

### DIFF
--- a/examples/sample-podinfo-app/sample-podinfo-app.yaml
+++ b/examples/sample-podinfo-app/sample-podinfo-app.yaml
@@ -5,6 +5,13 @@ metadata:
 #  namespace: xxx TODO should this live in its own namespace?
 spec:
   template:
+    metadata:
+      annotations:
+        # For testing purposes set request-per-second to 1 to force scaling
+        autoscaling.knative.dev/target: "1"
+        autoscaling.knative.dev/metric: "rps"
+      labels:
+        service: "podinfo"
     spec:
       containers:
         - name: podinfod

--- a/examples/sample-podinfo-app/sample_podinfo_app_test.go
+++ b/examples/sample-podinfo-app/sample_podinfo_app_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 	"testing"
 	"time"
@@ -37,6 +38,17 @@ func TestSamplePodInfoApp(t *testing.T) {
 		t.Run("version", testVersion)
 		t.Run("statusCode", testStatusCode)
 	})
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: "service=podinfo",
+	}
+
+	// podinfo is configured to scale using rps metric with a target of 1
+	// we've just executed 3 tests in parallel so knative will scale podinfo up
+	pods := k8s.ListPods(t, kubectlOptions, listOptions)
+
+	assert.NotNil(t, pods)
+	assert.Greater(t, len(pods), 1)
 
 	// =============================================================
 	k8s.KubectlDelete(t, kubectlOptions, "sample-podinfo-app.yaml")

--- a/scripts/run-test.sh
+++ b/scripts/run-test.sh
@@ -39,6 +39,7 @@ echo "Running test on ${PROJECT_PATH}"
 cd $PROJECT_PATH
 go mod init test || true
 go install . || true
+go clean -testcache
 go test . -v -timeout=30m
 
 if [ "$PROJECT_TYPE" == "integration" ]; then


### PR DESCRIPTION
## What does this PR do?

Adds an additional test to the podinfo integration test suite.  Aim is to demonstrate that knative is scaling the service out after receiving a certain number of requests within a given duration

## Related issues

#25 

## Checklist before merging

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have checked the [contributing document](../CONTRIBUTING.MD).
- [ ] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
- [ ] I have added tests that prove my fix is effective or that my feature works.
