### PR TITLE
ci: enable automerge on renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,10 @@
   "packageRules":
   [
     {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
       "matchPaths": ["addons/istio/**"],
       "groupName": "Istio Helm Chart"
     }


### PR DESCRIPTION
## What does this PR do?

After PR https://github.com/nearform/k8s-kurated-addons/pull/112 should be now safe to re-enable the automerge functionality on renovate PRs.

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
- [x] I have added tests that prove my fix is effective or that my feature works.
