### PR TITLE
feat: add certificate for ngrok tcp endpoints

### DIFF
--- a/manifests/kind/templates/cluster.yaml
+++ b/manifests/kind/templates/cluster.yaml
@@ -5,6 +5,9 @@ kubeadmConfigPatches:
 - |-
   kind: ClusterConfiguration
   apiServer:
+  {{- if .Values.certSANs }}
+    certSANs: {{ .Values.certSANs | toYaml | nindent 6 }}
+  {{- end }}
     extraArgs:
       oidc-issuer-url: https://dex.kube.local
       oidc-client-id: kubelogin

--- a/manifests/kind/values.yaml
+++ b/manifests/kind/values.yaml
@@ -1,0 +1,5 @@
+---
+certSANs:
+  - "127.0.0.1"
+  - "localhost"
+  - "*.tcp.ngrok.io"


### PR DESCRIPTION
## What does this PR do?

This is only meant to be used when testing the deployment from external pilelines (eg. Github actions).

If you want to expose the cluster you can use the command

```
ngrok tcp --region=us <api-port>
```

## Related issues

Please include a link to the issues related to this Pull Request.

## Checklist before merging

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have checked the [contributing document](../CONTRIBUTING.MD).
- [x] I have checked the existing [Pull Requests](https://github.com/nearform/k8s-kurated-addons/pulls) to see whether someone else has raised a similar idea or question.
- [ ] I have added tests that prove my fix is effective or that my feature works.
